### PR TITLE
fix a hang bug on wait_ready

### DIFF
--- a/cabot_site_large_room/cabot_site_large_room/tests.py
+++ b/cabot_site_large_room/cabot_site_large_room/tests.py
@@ -27,7 +27,7 @@ def checks(tester):
 
 
 def wait_ready(tester):
-    tester.wait_ready()
+    tester.wait_localization_started()
 
 
 def _goto_target1(tester):

--- a/cabot_site_large_room/cabot_site_large_room/tests_crowd.py
+++ b/cabot_site_large_room/cabot_site_large_room/tests_crowd.py
@@ -32,7 +32,7 @@ def checks(tester):
 
 
 def wait_ready(tester):
-    tester.wait_ready()
+    tester.wait_localization_started()
 
 
 def _goto_target1(tester):


### PR DESCRIPTION
以下のコマンドで歩行者シミュレーション`cabot_site_large_room`のテストを実行した際に、`Calling wait_ready`から処理が進まないバグを修正しました。
ご確認の程よろしくお願いいたします。

**テスト実行コマンド**
```bash
cd ~/cabot/cabot-navigation
./launch.sh -s -S cabot_site_large_room -t
```