### PR TITLE
Matsumura/add test case reproduce zero people speed

### DIFF
--- a/cabot_site_large_room/cabot_site_large_room/tests.py
+++ b/cabot_site_large_room/cabot_site_large_room/tests.py
@@ -400,3 +400,31 @@ def test_category3_case1_move_across_a_pedestrian_proceed(tester):
     _add_metric_condition_lt(tester, "time_not_moving", 3.8) # 3.8 is the average value of 5 runs with a 10% margin added.
     _add_metric_condition_lt(tester, "robot_on_person_collision_count", 1)
     _goto_target1(tester)
+
+def test_category3_case2_approach_a_stationary_robot_repeat(tester):
+    tester.check_collision()
+    tester.reset_position()
+
+    actors=[
+        {
+            "name": 'actor0',
+            "module": "pedestrian.walk_across",
+            "params": {
+                "init_x": -0.5,
+                "init_y": 5.0,
+                "init_a": -90.0,
+                "velocity": 0.95,
+                "goal_x": -0.5,
+                "goal_y": 3.0,
+                "repeat": 1,
+                "pause_distance": 3.0
+            },
+        },
+    ]
+
+    _setup_actors(tester, actors=actors)
+    _add_metric_condition_lt(tester, "total_time", 18) # 18 is the average value of 5 runs with a 10% margin added when the actor is stationary.
+    _add_metric_condition_lt(tester, "robot_path_length", 11.9) # 11.9 is the average value of 5 runs with a 10% margin added when the actor is stationary.
+    _add_metric_condition_lt(tester, "time_not_moving", 3.6) # 3.6 is the average value of 5 runs with a 10% margin added when the actor is stationary.
+    _add_metric_condition_lt(tester, "robot_on_person_collision_count", 1)
+    _goto_target1(tester)

--- a/cabot_site_large_room/cabot_site_large_room/tests.py
+++ b/cabot_site_large_room/cabot_site_large_room/tests.py
@@ -401,7 +401,16 @@ def test_category3_case1_move_across_a_pedestrian_proceed(tester):
     _add_metric_condition_lt(tester, "robot_on_person_collision_count", 1)
     _goto_target1(tester)
 
-def test_category3_case2_approach_a_stationary_robot_repeat(tester):
+def test_category3_case2_approach_the_stationary_robot_from_left_repeat(tester):
+    tester.set_people_detection_range(
+        min_range=0.0,
+        max_range=100.0,
+        min_angle=-3.142,
+        max_angle=3.142,
+        occlusion_radius=0.25,
+        divider_distance_m=0.05,
+        divider_angle_deg=1.0
+    )
     tester.check_collision()
     tester.reset_position()
 
@@ -428,3 +437,104 @@ def test_category3_case2_approach_a_stationary_robot_repeat(tester):
     _add_metric_condition_lt(tester, "time_not_moving", 3.6) # 3.6 is the average value of 5 runs with a 10% margin added when the actor is stationary.
     _add_metric_condition_lt(tester, "robot_on_person_collision_count", 1)
     _goto_target1(tester)
+    tester.set_people_detection_range(
+        min_range=0.29, # 0.07 is the distance from the center of the LiDAR to the front of the front camera.
+        max_range=7.07, # 0.07 is the distance from the center of the LiDAR to the front of the front camera.
+        min_angle=-2.28,
+        max_angle=2.28,
+        occlusion_radius=0.25,
+        divider_distance_m=0.05,
+        divider_angle_deg=1.0
+    )
+
+def test_category3_case2_approach_the_stationary_robot_from_right_repeat(tester):
+    tester.set_people_detection_range(
+        min_range=0.0,
+        max_range=100.0,
+        min_angle=-3.142,
+        max_angle=3.142,
+        occlusion_radius=0.25,
+        divider_distance_m=0.05,
+        divider_angle_deg=1.0
+    )
+    tester.check_collision()
+    tester.reset_position()
+
+    actors=[
+        {
+            "name": 'actor0',
+            "module": "pedestrian.walk_across",
+            "params": {
+                "init_x": -0.5,
+                "init_y": -5.0,
+                "init_a": 90.0,
+                "velocity": 0.95,
+                "goal_x": -0.5,
+                "goal_y": -3.0,
+                "repeat": 1,
+                "pause_distance": 3.0
+            },
+        },
+    ]
+
+    _setup_actors(tester, actors=actors)
+    _add_metric_condition_lt(tester, "total_time", 18) # 18 is the average value of 5 runs with a 10% margin added when the actor is stationary.
+    _add_metric_condition_lt(tester, "robot_path_length", 11.9) # 11.9 is the average value of 5 runs with a 10% margin added when the actor is stationary.
+    _add_metric_condition_lt(tester, "time_not_moving", 3.6) # 3.6 is the average value of 5 runs with a 10% margin added when the actor is stationary.
+    _add_metric_condition_lt(tester, "robot_on_person_collision_count", 1)
+    _goto_target1(tester)
+    tester.set_people_detection_range(
+        min_range=0.29, # 0.07 is the distance from the center of the LiDAR to the front of the front camera.
+        max_range=7.07, # 0.07 is the distance from the center of the LiDAR to the front of the front camera.
+        min_angle=-2.28,
+        max_angle=2.28,
+        occlusion_radius=0.25,
+        divider_distance_m=0.05,
+        divider_angle_deg=1.0
+    )
+
+def test_category3_case2_approach_the_stationary_robot_from_behind_repeat(tester):
+    tester.set_people_detection_range(
+        min_range=0.0,
+        max_range=100.0,
+        min_angle=-3.142,
+        max_angle=3.142,
+        occlusion_radius=0.25,
+        divider_distance_m=0.05,
+        divider_angle_deg=1.0
+    )
+    tester.check_collision()
+    tester.reset_position()
+
+    actors=[
+        {
+            "name": 'actor0',
+            "module": "pedestrian.walk_across",
+            "params": {
+                "init_x": -5.0,
+                "init_y": -0.5,
+                "init_a": 0.0,
+                "velocity": 0.95,
+                "goal_x": -3.0,
+                "goal_y": -0.5,
+                "repeat": 1,
+                "pause_distance": 3.0
+            },
+        },
+    ]
+
+    _setup_actors(tester, actors=actors)
+    _add_metric_condition_lt(tester, "total_time", 18) # 18 is the average value of 5 runs with a 10% margin added when the actor is stationary.
+    _add_metric_condition_lt(tester, "robot_path_length", 11.9) # 11.9 is the average value of 5 runs with a 10% margin added when the actor is stationary.
+    _add_metric_condition_lt(tester, "time_not_moving", 3.6) # 3.6 is the average value of 5 runs with a 10% margin added when the actor is stationary.
+    _add_metric_condition_lt(tester, "robot_on_person_collision_count", 1)
+    _goto_target1(tester)
+    tester.set_people_detection_range(
+        min_range=0.29, # 0.07 is the distance from the center of the LiDAR to the front of the front camera.
+        max_range=7.07, # 0.07 is the distance from the center of the LiDAR to the front of the front camera.
+        min_angle=-2.28,
+        max_angle=2.28,
+        occlusion_radius=0.25,
+        divider_distance_m=0.05,
+        divider_angle_deg=1.0
+    )

--- a/cabot_site_large_room/cabot_site_large_room/tests_crowd.py
+++ b/cabot_site_large_room/cabot_site_large_room/tests_crowd.py
@@ -423,6 +423,51 @@ def test_category6_case1_sfm_actors(tester):
     _goto_target1(tester)
 
 
+def test_category6_case1_sfm_actors_variant1_perfect_people_detection(tester):
+    # 6.1 crowd navigation
+    tester.set_people_detection_range(
+        min_range=0.0,
+        max_range=100.0,
+        min_angle=-3.142,
+        max_angle=3.142,
+        occlusion_radius=0.25,
+        divider_distance_m=0.05,
+        divider_angle_deg=1.0
+    )
+    tester.check_collision()
+    bound = 5.0
+    actors = []
+    n_actors = 10
+    for i in range(0, n_actors):
+        actors.append({
+            "name": f"actor{i}",
+            "module": "pedestrian.walk_sfm",
+            "params": {
+                "init_x": random.uniform(-bound, bound),
+                "init_y": random.uniform(-bound, bound),
+                "init_a": random.uniform(-180.0, 180.0),
+                "velocity": 1.0,
+                "n_actors": n_actors,
+                "min_x": -bound,
+                "max_x": bound,
+                "min_y": -bound,
+                "max_y": bound,
+            },
+        })
+    tester.reset_position(x=-6.0)
+    _setup_actors_with_allocation(tester, actors=actors)
+    _goto_target1(tester)
+    tester.set_people_detection_range(
+        min_range=0.29, # 0.07 is the distance from the center of the LiDAR to the front of the front camera.
+        max_range=7.07, # 0.07 is the distance from the center of the LiDAR to the front of the front camera.
+        min_angle=-2.28,
+        max_angle=2.28,
+        occlusion_radius=0.25,
+        divider_distance_m=0.05,
+        divider_angle_deg=1.0
+    )
+
+
 def test_category6_case2_sfm_parallel_traffic(tester):
     # 6.2 parallel traffic
     tester.check_collision()

--- a/cabot_site_large_room/cabot_site_large_room/tests_crowd.py
+++ b/cabot_site_large_room/cabot_site_large_room/tests_crowd.py
@@ -515,6 +515,9 @@ def test_category6_case1_sfm_actors_variant1_perfect_people_detection(tester):
         })
     tester.reset_position(x=-6.0)
     _setup_actors_with_allocation(tester, actors=actors)
+    _add_metric_condition_lt(tester, "total_time", 120) # 120 is the test case timeout value.
+    _add_metric_condition_lt(tester, "time_not_moving", 3.6) # 3.6 is the average value of 5 runs in test_category6_case1_sfm_actors with a 100% margin added.
+    _add_metric_condition_lt(tester, "robot_on_person_collision_count", 1)
     _goto_target1(tester)
     tester.set_people_detection_range(
         min_range=0.29, # 0.07 is the distance from the center of the LiDAR to the front of the front camera.


### PR DESCRIPTION
進行方向に人がいないにも関わらずpeople_speedがゼロになるバグが発生しております。
本PRでは、そのバグ修正に伴い、バグを再現するテストケースを作成しました。

tests.py
- `test_category3_case2_approach_the_stationary_robot_from_left_repeat`: ロボットの左から人が接近するテストケース（現時点ではバグが再現する）
- `test_category3_case2_approach_the_stationary_robot_from_right_repeat`: ロボットの右から人が接近するテストケース（現時点ではバグが再現する）
- `test_category3_case2_approach_the_stationary_robot_from_behind_repeat`: ロボットの後方から人が接近するテストケース（現時点ではバグが再現しないが、バグ修正時の確認用テストケースとして追加しております。）

tests_crawd.py
- `test_category6_case1_sfm_actors_variant1_perfect_people_detection`: 大勢の人がランダムな方向に行き来するテストケース（現時点ではバグが再現する）

@daisukes さん @muratams さん
レビューの程よろしくお願いいたします。